### PR TITLE
Missing $ in btrace.sh

### DIFF
--- a/plugins/014_btrace/btrace.sh
+++ b/plugins/014_btrace/btrace.sh
@@ -2,7 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -x
 
-if [ "true" == "$BTRACE_ENABLED" ] || [ -n "$BTRACE_SCRIPT" ] || [ -n "BTRACE_SCRIPT_URL" ]; then
+if [ "true" == "$BTRACE_ENABLED" ] || [ -n "$BTRACE_SCRIPT" ] || [ -n "$BTRACE_SCRIPT_URL" ]; then
   plugin-is-active "BTRACE"
 
   BTRACE_DIR=/opt/btrace

--- a/plugins/014_btrace/btrace.sh
+++ b/plugins/014_btrace/btrace.sh
@@ -1,6 +1,5 @@
 #/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-set -x
 
 if [ "true" == "$BTRACE_ENABLED" ] || [ -n "$BTRACE_SCRIPT" ] || [ -n "$BTRACE_SCRIPT_URL" ]; then
   plugin-is-active "BTRACE"


### PR DESCRIPTION
BTRACE plugin is always activated due to missing `$` in `[ -n "BTRACE_SCRIPT_URL" ]` check.