### PR TITLE
envtoconf plugin: create $CONF_DIR if needed

### DIFF
--- a/plugins/010_envtoconf/envtoconf.sh
+++ b/plugins/010_envtoconf/envtoconf.sh
@@ -2,7 +2,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ "true" == "$ENVTOCONF_ENABLED" ] || [ "$CONFIG_TYPE" == "simple" ]; then
    plugin-is-active "ENVTOCONF"
-   $DIR/envtoconf --outputdir $CONF_DIR $@
+   [[ -n $CONF_DIR ]] && mkdir -p "$CONF_DIR"
+   $DIR/envtoconf --outputdir "$CONF_DIR" $@
 fi
 
 call-next-plugin "$@"


### PR DESCRIPTION
Currently it is necessary to create `$CONF_DIR` at child image build time, since the plugin runs before child image start command.  However, the variable can be overridden at runtime, which might cause a conflict.

This small change creates the directory if necessary.