### PR TITLE
git describe fails due to wrong directory

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo "Flokkr launcher script $(git --work-tree=$DIR describe --tags)"
+echo "Flokkr launcher script $(git -C $DIR describe --tags)"
 plugin-is-active() {
   echo "===== Plugin is activated $1 ====="
 }

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo "Flokkr launcher script $(git -C $DIR describe --tags)"
+echo "Flokkr launcher script $(git --git-dir=$DIR/.git describe --tags)"
 plugin-is-active() {
   echo "===== Plugin is activated $1 ====="
 }


### PR DESCRIPTION
`git --work-dir=$DIR describe` fails unless working directory is `/opt/launcher` or one of its subtree.
`git -C $DIR describe` works in all locations.

```
$ docker run -it --rm flokkr/hadoop:ozonefs bash
fatal: Not a git repository (or any of the parent directories): .git
Flokkr launcher script

===== Plugin is activated ENVTOCONF =====
======================================
*** Launching "bash"
bash-4.3$ export DIR=$(dirname /opt/launcher/launcher.sh)
bash-4.3$ pwd
/opt/hadoop
bash-4.3$ git --work-tree=$DIR describe --tags
fatal: Not a git repository (or any of the parent directories): .git
bash-4.3$ git -C $DIR describe --tags
1.0-2-g534ec4b
bash-4.3$ cd $DIR
bash-4.3$ git --work-tree=$DIR describe --tags
1.0-2-g534ec4b
bash-4.3$ git -C $DIR describe --tags
1.0-2-g534ec4b
bash-4.3$ cd $DIR/plugins
bash-4.3$ git --work-tree=$DIR describe --tags
1.0-2-g534ec4b
bash-4.3$ git -C $DIR describe --tags
1.0-2-g534ec4b
```
